### PR TITLE
types: Switch from buffer reference to attached buffer

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -114,7 +114,7 @@ void CPointerManager::setCursorBuffer(SP<Aquamarine::IBuffer> buf, const Vector2
     resetCursorImage(false);
 
     if (buf) {
-        currentCursorImage.size    = buf->size;
+        currentCursorImage.size    = buf->getSize();
         currentCursorImage.pBuffer = buf;
     }
 

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -99,9 +99,9 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
 CLinuxDMABuffer::CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs attrs) {
     buffer = makeShared<CDMABuffer>(id, client, attrs);
 
-    buffer->resource->buffer = buffer;
+    buffer->getResource()->buffer = buffer;
 
-    listeners.bufferResourceDestroy = buffer->events.destroy.registerListener([this](std::any d) {
+    listeners.bufferResourceDestroy = buffer->getDestroyEvent().registerListener([this](std::any d) {
         listeners.bufferResourceDestroy.reset();
         PROTO::linuxDma->destroyResource(this);
     });
@@ -111,8 +111,8 @@ CLinuxDMABuffer::CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDM
 }
 
 CLinuxDMABuffer::~CLinuxDMABuffer() {
-    if (buffer && buffer->resource)
-        buffer->resource->sendRelease();
+    if (buffer && buffer->getResource())
+        buffer->getResource()->sendRelease();
 
     buffer.reset();
     listeners.bufferResourceDestroy.reset();
@@ -225,7 +225,7 @@ void CLinuxDMABUFParamsResource::create(uint32_t id) {
     }
 
     if (!id)
-        resource->sendCreated(PROTO::linuxDma->m_vBuffers.back()->buffer->resource->getResource());
+        resource->sendCreated(PROTO::linuxDma->m_vBuffers.back()->buffer->getResource()->getResource());
 
     createdBuffer = buf;
 }

--- a/src/protocols/MesaDRM.cpp
+++ b/src/protocols/MesaDRM.cpp
@@ -11,10 +11,10 @@ CMesaDRMBufferResource::CMesaDRMBufferResource(uint32_t id, wl_client* client, A
         LOGM(LOG, " | plane {}: mod {} fd {} stride {} offset {}", i, attrs_.modifier, attrs_.fds[i], attrs_.strides[i], attrs_.offsets[i]);
     }
 
-    buffer                   = makeShared<CDMABuffer>(id, client, attrs_);
-    buffer->resource->buffer = buffer;
+    buffer                        = makeShared<CDMABuffer>(id, client, attrs_);
+    buffer->getResource()->buffer = buffer;
 
-    listeners.bufferResourceDestroy = buffer->events.destroy.registerListener([this](std::any d) {
+    listeners.bufferResourceDestroy = buffer->getDestroyEvent().registerListener([this](std::any d) {
         listeners.bufferResourceDestroy.reset();
         PROTO::mesaDRM->destroyResource(this);
     });
@@ -24,8 +24,8 @@ CMesaDRMBufferResource::CMesaDRMBufferResource(uint32_t id, wl_client* client, A
 }
 
 CMesaDRMBufferResource::~CMesaDRMBufferResource() {
-    if (buffer && buffer->resource)
-        buffer->resource->sendRelease();
+    if (buffer && buffer->getResource())
+        buffer->getResource()->sendRelease();
     buffer.reset();
     listeners.bufferResourceDestroy.reset();
 }
@@ -94,7 +94,7 @@ CMesaDRMResource::CMesaDRMResource(SP<CWlDrm> resource_) : resource(resource_) {
             }
 
             // append instance so that buffer knows its owner
-            RESOURCE->buffer->resource->buffer = RESOURCE->buffer;
+            RESOURCE->buffer->getResource()->buffer = RESOURCE->buffer;
         });
 
     resource->sendDevice(PROTO::mesaDRM->nodeName.c_str());

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../defines.hpp"
+#include "protocols/types/Buffer.hpp"
 #include "wlr-screencopy-unstable-v1.hpp"
 #include "WaylandProtocol.hpp"
 
@@ -65,7 +66,7 @@ class CScreencopyFrame {
     bool                       withDamage      = false;
     bool                       lockedSWCursors = false;
 
-    WP<IHLBuffer>              buffer;
+    WP<CHLAttachedBuffer>      buffer;
     bool                       bufferDMA    = false;
     uint32_t                   shmFormat    = 0;
     uint32_t                   dmabufFormat = 0;

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -67,9 +67,9 @@ CSinglePixelBufferResource::CSinglePixelBufferResource(uint32_t id, wl_client* c
     if UNLIKELY (!buffer->good())
         return;
 
-    buffer->resource->buffer = buffer;
+    buffer->getResource()->buffer = buffer;
 
-    listeners.bufferResourceDestroy = buffer->events.destroy.registerListener([this](std::any d) {
+    listeners.bufferResourceDestroy = buffer->getDestroyEvent().registerListener([this](std::any d) {
         listeners.bufferResourceDestroy.reset();
         PROTO::singlePixel->destroyResource(this);
     });

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -73,10 +73,7 @@ bool CToplevelExportClient::good() {
     return resource->resource();
 }
 
-CToplevelExportFrame::~CToplevelExportFrame() {
-    if (buffer && buffer->locked())
-        buffer->unlock();
-}
+CToplevelExportFrame::~CToplevelExportFrame() {}
 
 CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> resource_, int32_t overlayCursor_, PHLWINDOW pWindow_) : resource(resource_), pWindow(pWindow_) {
     if UNLIKELY (!good())
@@ -153,15 +150,13 @@ void CToplevelExportFrame::copy(CHyprlandToplevelExportFrameV1* pFrame, wl_resou
     }
 
     const auto PBUFFER = CWLBufferResource::fromResource(buffer_);
-    if UNLIKELY (!PBUFFER) {
+    if UNLIKELY (!PBUFFER || !PBUFFER->buffer) {
         resource->error(HYPRLAND_TOPLEVEL_EXPORT_FRAME_V1_ERROR_INVALID_BUFFER, "invalid buffer");
         PROTO::toplevelExport->destroyResource(this);
         return;
     }
 
-    PBUFFER->buffer->lock();
-
-    if UNLIKELY (PBUFFER->buffer->size != box.size()) {
+    if UNLIKELY (PBUFFER->buffer->getSize() != box.size()) {
         resource->error(HYPRLAND_TOPLEVEL_EXPORT_FRAME_V1_ERROR_INVALID_BUFFER, "invalid buffer dimensions");
         PROTO::toplevelExport->destroyResource(this);
         return;
@@ -197,7 +192,7 @@ void CToplevelExportFrame::copy(CHyprlandToplevelExportFrameV1* pFrame, wl_resou
         return;
     }
 
-    buffer = PBUFFER->buffer;
+    buffer = makeShared<CHLAttachedBuffer>(PBUFFER->buffer.lock());
 
     m_ignoreDamage = ignoreDamage;
 

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -4,6 +4,7 @@
 #include "hyprland-toplevel-export-v1.hpp"
 #include "WaylandProtocol.hpp"
 #include "Screencopy.hpp"
+#include "protocols/types/Buffer.hpp"
 
 #include <vector>
 
@@ -55,7 +56,7 @@ class CToplevelExportFrame {
     bool                               m_ignoreDamage         = false;
     bool                               lockedSWCursors        = false;
 
-    WP<IHLBuffer>                      buffer;
+    WP<CHLAttachedBuffer>              buffer;
     bool                               bufferDMA    = false;
     uint32_t                           shmFormat    = 0;
     uint32_t                           dmabufFormat = 0;

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -163,7 +163,7 @@ CWLSHMPoolResource::CWLSHMPoolResource(SP<CWlShmPool> resource_, CFileDescriptor
         }
 
         // append instance so that buffer knows its owner
-        RESOURCE->resource->buffer = RESOURCE;
+        RESOURCE->getResource()->buffer = RESOURCE;
     });
 
     if UNLIKELY (pool->data == MAP_FAILED)

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -4,10 +4,6 @@
 
 IHLBuffer::~IHLBuffer() {}
 
-void IHLBuffer::sendRelease() {
-    resource->sendRelease();
-}
-
 const SP<CTexture>& IHLBuffer::getTexture() {
     return texture;
 }
@@ -47,8 +43,20 @@ bool CHLAttachedBuffer::good() {
     return buffer->good();
 }
 
-void CHLAttachedBuffer::sendRelease() {
-    buffer->sendRelease();
+Aquamarine::SDMABUFAttrs CHLAttachedBuffer::dmabuf() {
+    return buffer->dmabuf();
+}
+
+Aquamarine::SSHMAttrs CHLAttachedBuffer::shm() {
+    return buffer->shm();
+}
+
+std::tuple<uint8_t*, uint32_t, size_t> CHLAttachedBuffer::beginDataPtr(uint32_t flags) {
+    return buffer->beginDataPtr(flags);
+}
+
+void CHLAttachedBuffer::endDataPtr() {
+    return buffer->endDataPtr();
 }
 
 bool CHLAttachedBuffer::getOpaque() {

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -56,7 +56,7 @@ std::tuple<uint8_t*, uint32_t, size_t> CHLAttachedBuffer::beginDataPtr(uint32_t 
 }
 
 void CHLAttachedBuffer::endDataPtr() {
-    return buffer->endDataPtr();
+    buffer->endDataPtr();
 }
 
 bool CHLAttachedBuffer::getOpaque() {

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -17,7 +17,6 @@ class IHLBuffer : public Aquamarine::IBuffer {
     virtual void                          update(const CRegion& damage) = 0;
     virtual bool                          isSynchronous()               = 0; // whether the updates to this buffer are synchronous, aka happen over cpu
     virtual bool                          good()                        = 0;
-    virtual void                          sendRelease();
 
     virtual const SP<CTexture>&           getTexture();
     virtual const SP<CWLBufferResource>&  getResource();
@@ -33,23 +32,26 @@ class CHLAttachedBuffer : public IHLBuffer {
     explicit CHLAttachedBuffer(SP<IHLBuffer> buffer);
     virtual ~CHLAttachedBuffer();
 
-    virtual Aquamarine::eBufferCapability   caps();
-    virtual Aquamarine::eBufferType         type();
-    virtual void                            update(const CRegion& damage);
-    virtual bool                            isSynchronous(); // whether the updates to this buffer are synchronous, aka happen over cpu
-    virtual bool                            good();
-    virtual void                            sendRelease();
+    virtual Aquamarine::eBufferCapability          caps();
+    virtual Aquamarine::eBufferType                type();
+    virtual void                                   update(const CRegion& damage);
+    virtual bool                                   isSynchronous(); // whether the updates to this buffer are synchronous, aka happen over cpu
+    virtual bool                                   good();
+    virtual Aquamarine::SDMABUFAttrs               dmabuf();
+    virtual Aquamarine::SSHMAttrs                  shm();
+    virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
+    virtual void                                   endDataPtr();
 
-    virtual bool                            getOpaque();
-    virtual Hyprutils::Math::Vector2D&      getSize();
-    virtual Aquamarine::CAttachmentManager& getAttachments();
-    virtual Hyprutils::Signal::CSignal&     getDestroyEvent();
-    virtual const SP<CTexture>&             getTexture();
-    virtual const SP<CWLBufferResource>&    getResource();
+    virtual bool                                   getOpaque();
+    virtual Hyprutils::Math::Vector2D&             getSize();
+    virtual Aquamarine::CAttachmentManager&        getAttachments();
+    virtual Hyprutils::Signal::CSignal&            getDestroyEvent();
+    virtual const SP<CTexture>&                    getTexture();
+    virtual const SP<CWLBufferResource>&           getResource();
 
-    UP<CDRMSyncPointState>                  acquire;
-    UP<CDRMSyncPointState>                  release;
-    UP<CSyncReleaser>                       syncReleaser;
+    UP<CDRMSyncPointState>                         acquire;
+    UP<CDRMSyncPointState>                         release;
+    UP<CSyncReleaser>                              syncReleaser;
 
   private:
     SP<IHLBuffer> buffer;

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -3,17 +3,17 @@
 #include "../../helpers/math/Math.hpp"
 #include "../WaylandProtocol.hpp"
 
-class CHLBufferReference;
+class CHLAttachedBuffer;
 class CTexture;
 
 struct SSurfaceState {
-    CRegion                opaque, input = CBox{{}, {INT32_MAX, INT32_MAX}}, damage, bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}} /* initial damage */;
-    wl_output_transform    transform = WL_OUTPUT_TRANSFORM_NORMAL;
-    int                    scale     = 1;
-    SP<CHLBufferReference> buffer; // buffer ref will be released once the buffer is no longer locked. For checking if a buffer is attached to this state, check texture.
-    SP<CTexture>           texture;
-    Vector2D               offset;
-    Vector2D               size, bufferSize;
+    CRegion               opaque, input = CBox{{}, {INT32_MAX, INT32_MAX}}, damage, bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}} /* initial damage */;
+    wl_output_transform   transform = WL_OUTPUT_TRANSFORM_NORMAL;
+    int                   scale     = 1;
+    SP<CHLAttachedBuffer> buffer; // buffer ref will be released once the buffer is no longer locked. For checking if a buffer is attached to this state, check texture.
+    SP<CTexture>          texture;
+    Vector2D              offset;
+    Vector2D              size, bufferSize;
     struct {
         bool     hasDestination = false;
         bool     hasSource      = false;

--- a/src/protocols/types/WLBuffer.cpp
+++ b/src/protocols/types/WLBuffer.cpp
@@ -12,12 +12,12 @@ CWLBufferResource::CWLBufferResource(WP<CWlBuffer> resource_) : resource(resourc
     resource->setOnDestroy([this](CWlBuffer* r) {
         if (buffer.expired())
             return;
-        buffer->events.destroy.emit();
+        buffer->getDestroyEvent().emit();
     });
     resource->setDestroy([this](CWlBuffer* r) {
         if (buffer.expired())
             return;
-        buffer->events.destroy.emit();
+        buffer->getDestroyEvent().emit();
     });
 
     resource->setData(this);

--- a/src/render/Renderbuffer.cpp
+++ b/src/render/Renderbuffer.cpp
@@ -37,7 +37,7 @@ CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : 
 
     glGenFramebuffers(1, &m_sFramebuffer.m_iFb);
     m_sFramebuffer.m_iFbAllocated = true;
-    m_sFramebuffer.m_vSize        = buffer->size;
+    m_sFramebuffer.m_vSize        = buffer->getSize();
     m_sFramebuffer.bind();
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_iRBO);
 
@@ -48,7 +48,7 @@ CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : 
 
     m_sFramebuffer.unbind();
 
-    listeners.destroyBuffer = buffer->events.destroy.registerListener([this](std::any d) { g_pHyprRenderer->onRenderbufferDestroy(this); });
+    listeners.destroyBuffer = buffer->getDestroyEvent().registerListener([this](std::any d) { g_pHyprRenderer->onRenderbufferDestroy(this); });
 
     m_bGood = true;
 }

--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -27,7 +27,7 @@ CTexture::CTexture(const SP<Aquamarine::IBuffer> buffer, bool keepDataCopy) : m_
     if (!buffer)
         return;
 
-    m_bOpaque = buffer->opaque;
+    m_bOpaque = buffer->getOpaque();
 
     auto attrs = buffer->dmabuf();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Instead of having a buffer reference type that isn't interchangeable with buffers themselves, this adds a new "attached buffer" type, which represents a buffer that's been attached to Hyprland. That way, existing abstractions in aquamarine can use one of these "attached buffers" while still just taking in a normal IBuffer, and all the lifetime code works naturally instead of having to rely on awkward lockedByBuffer and bufferRelease mechanisms.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Requires https://github.com/hyprwm/aquamarine/pull/157

This PR points into https://github.com/hyprwm/Hyprland/pull/9437

#### Is it ready for merging, or does it need work?
Ready for merging