### PR TITLE
types: Defer buffer sync releaser until unlock

### DIFF
--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -146,7 +146,7 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurf
         surface->pending.newBuffer = false;
         surface->pending.buffer.reset();
 
-        state.buffer->syncReleaser = state.buffer->release->createSyncRelease();
+        state.buffer->buffer->syncReleaser = state.buffer->release->createSyncRelease();
         state.buffer->acquire->addWaiter([this, surf = surface, it = std::prev(pendingStates.end())] {
             if (!surf)
                 return;

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -18,8 +18,10 @@ void IHLBuffer::unlock() {
 
     ASSERT(nLocks >= 0);
 
-    if (nLocks == 0)
+    if (nLocks == 0) {
         sendRelease();
+        syncReleaser.reset();
+    }
 }
 
 bool IHLBuffer::locked() {

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -27,6 +27,7 @@ class IHLBuffer : public Aquamarine::IBuffer {
     SP<CTexture>                          texture;
     bool                                  opaque = false;
     SP<CWLBufferResource>                 resource;
+    UP<CSyncReleaser>                     syncReleaser;
 
     struct {
         CHyprSignalListener backendRelease;
@@ -47,7 +48,6 @@ class CHLBufferReference {
     WP<IHLBuffer>          buffer;
     UP<CDRMSyncPointState> acquire;
     UP<CDRMSyncPointState> release;
-    UP<CSyncReleaser>      syncReleaser;
 
   private:
     WP<CWLSurfaceResource> surface;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1572,10 +1572,10 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         Debug::log(TRACE, "Explicit: can't add sync, EGLSync failed");
     else {
         for (auto const& e : explicitPresented) {
-            if (!e->current.buffer || !e->current.buffer->syncReleaser)
+            if (!e->current.buffer || !e->current.buffer->buffer || !e->current.buffer->buffer->syncReleaser)
                 continue;
 
-            e->current.buffer->syncReleaser->addReleaseSync(sync);
+            e->current.buffer->buffer->syncReleaser->addReleaseSync(sync);
         }
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Points into https://github.com/hyprwm/Hyprland/pull/9437

Defers the CSyncReleaser releasing until after the buffer is unlocked, instead of happening earlier when all references are dropped. This is important because with direct scanout, buffer unlocking is deferred until the backendRelease event is emitted, which happens later than the references being dropped.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Ready for merging (into eventfd)